### PR TITLE
Handle missing Windows launcher when running app

### DIFF
--- a/PyExeGen
+++ b/PyExeGen
@@ -473,7 +473,11 @@ class PyInstallerGUI:
             return
 
         # иначе — запускаем .py
-        runner = self._get_runner(self.opts.arch)
+        try:
+            runner = self._get_runner(self.opts.arch)
+        except FileNotFoundError as e:
+            self._show_error(str(e))
+            return
         cmd = runner + [self.opts.py_file]
         self._append_log(f"[Запуск .py] {' '.join(cmd)}\n")
         try:
@@ -575,6 +579,7 @@ class PyInstallerGUI:
         self.progress.stop()
         self.cancel_btn.configure(state="disabled")
         self._lock_controls(False)
+        self.process = None
         if err:
             self._show_error(err)
             return


### PR DESCRIPTION
## Summary
- show a friendly error if the requested Windows Python launcher architecture is unavailable when running the app
- clear the stored build process reference after a build finishes to avoid stale handles

## Testing
- python -m py_compile PyExeGen

------
https://chatgpt.com/codex/tasks/task_e_68e667de49988326a327151e06f34ae9